### PR TITLE
Add MGEN to Traffic Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ An [awesome list](https://github.com/sindresorhus/awesome) of resources to desig
 - [Ostinato](https://ostinato.org/) - Ostinato is a packet crafter, network traffic generator and analyzer with a friendly GUI
 - [SIPp](http://sipp.sourceforge.net/index.html) - SIPp is a free Open Source test tool / traffic generator for the SIP protocol.
 - [StarTrinity SIP Tester™](http://startrinity.com/VoIP/SipTester/SipTester.aspx) - (call generator, simulator) - VoIP monitoring and testing tool, VoIP recorder
+- [Multi-Generator](https://www.nrl.navy.mil/itd/ncs/products/mgen) - Multi-Generator (MGEN) is open source software that provides the ability to perform IP network performance tests and measurements using TCP and UDP/IP traffic.
 
 # Network Operations
 ## Network Automation


### PR DESCRIPTION
This commit adds the Multi-Generator (MGEN), an open source traffic
generator, to the "Network Simulators and Traffic Generators" section.

I have used MGEN for a few projects. It allows to specify traffic
patterns that match the expected network traffic in a flexible way.
This has allowed me (and colleagues) to create high data rate multicast
traffic for proof-of-concept implementation, identify network problems
with low data rate but bursty broadcast traffic, and verify rate limiter
settings for QoS configurations.