### PR TITLE
Add rkik to Network monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [GitNOps](https://github.com/mcgonagle/GitNops) - GitNops is an operational framework that takes DevOps best practices used for application development such as version control, collaboration, compliance, and CI/CD, and applies them to network automation.
 
 ## Network Monitoring
+- [rkik](https://github.com/aguacero7/rkik) - Light, easy-to-use monitoring tool for NTP servers
 - [perfSONAR](https://www.perfsonar.net) - Network measurement toolkit designed to provide federated coverage of paths, and help to establish end-to-end usage expectations.
 - [UDPing](https://github.com/yahoo/UDPing) - Measure latency and packet loss across a link.
 - [Vaping](https://github.com/20c/vaping) - vaping is a healthy alternative to smokeping.


### PR DESCRIPTION
Hey ! 

I would love to add rkik to the Network monitoring tool.
It does monitor / diagnose NTP servers easily, without being root, without running any heavy daemon, without applying time to your system.

It already has 40 stars on github and almost 3k downlaods on [crates.io](https://crates.io/crates/rkik).