### PR TITLE
Add Pilot Protocol to VPN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 
 ## VPN
 - [Firezone](https://github.com/firezone/firezone) - Open-source VPN server and egress firewall for Linux built on WireGuard. Firezone is easy to set up (all dependencies are bundled thanks to Chef Omnibus), secure, performant, and self hostable.
+- [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) - Overlay network stack for AI agents with virtual addresses, encrypted UDP tunnels (AES-256-GCM), NAT traversal, and mutual trust. Written in Go with zero dependencies.
 - [PiVPN](https://www.pivpn.io/) - Simplest OpenVPN setup and configuration, designed for Raspberry Pi.
 
 ## Network Services


### PR DESCRIPTION
Adds [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) to the VPN section.

Pilot Protocol is an overlay network stack that provides virtual addressing, encrypted UDP tunnels (X25519 + AES-256-GCM), NAT traversal (STUN, hole-punching, relay fallback), and a mutual trust handshake protocol. Written in Go with zero external dependencies.

- [Website](https://pilotprotocol.network)
- [Live dashboard](https://polo.pilotprotocol.network)
- [Wire specification](https://github.com/TeoSlayer/pilotprotocol/blob/main/docs/SPEC.md)