### PR TITLE
Add wanguard-notify to Security Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [Zeek](https://zeek.org/) - Zeek is an open source network security monitoring tool.
   - [zeek2es](https://github.com/corelight/zeek2es) - A Zeek log to Elastic/OpenSearch log converter.
 - [DrKeithJones.com](https://drkeithjones.com) - Keith Jones' blog on cyber security and security monitoring.
+- [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) - Alert bridge for Andrisoft Wanguard that forwards DDoS attack notifications to Slack, Discord, PagerDuty, Telegram, Microsoft Teams, email, and webhooks.
 
 ## Network Inventory
 - [infrahub](https://github.com/opsmill/infrahub) -  Infrahub is a graph-based data management platform with built-in version control, CI workflows, peer review, and API access. It’s purpose-built to power reliable infrastructure automation at scale.


### PR DESCRIPTION
Adds [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) to the **Security Monitoring** section.

**wanguard-notify** is an alert bridge for Andrisoft Wanguard that forwards DDoS attack notifications to Slack, Discord, PagerDuty, Telegram, Microsoft Teams, email, and generic webhooks. Wanguard is already represented in this section as a DDoS detection platform, and this tool extends its alerting capabilities to modern notification channels.

- MIT licensed, Python 3.8+, zero external dependencies
- Configurable as Wanguard's notification script
- PagerDuty auto-resolve on attack end