### PR TITLE
Add Flowtriq to Security Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [cPacket](https://www.cpacket.com) - Performance monitoring solutions that deliver real-time analysis and coverage (Commercial).
 - [Proxmox Mail Gateway](https://www.proxmox.com/en/proxmox-mail-gateway) - Open-source email security solution helping you to protect your mail server against all email threats the moment they emerge.
 - [FastNetMon](https://fastnetmon.com/) - DDoS detection tool (Open Source or Commercial).
+- [Flowtriq](https://github.com/Flowtriq/flowtriq-pfsense-opnsense) - DDoS detection for pfSense, OPNsense, and VyOS routers via NetFlow export, with real-time alerting and automated mitigation.
 - [PyREBox](https://github.com/Cisco-Talos/pyrebox) - Python scriptable Reverse Engineering Sandbox, a Virtual Machine instrumentation and inspection framework based on QEMU.
 - [Canary](https://canary.tools/) - Honeypot solution (commercial).
 - [CanaryTokens](https://canarytokens.org/generate) - Free honeytoken.


### PR DESCRIPTION
Adds [Flowtriq](https://flowtriq.com) to the Security Monitoring section.

Flowtriq is a DDoS detection platform with open-source integrations for pfSense, OPNsense, and VyOS routers. It works via NetFlow/sFlow/IPFIX export and provides real-time attack detection, alerting (Discord, Slack, email, PagerDuty), and automated mitigation (BGP FlowSpec, RTBH).

- GitHub: https://github.com/Flowtriq/flowtriq-pfsense-opnsense
- Also: https://github.com/Flowtriq/flowtriq-vyos

It fits naturally alongside FastNetMon in the Security Monitoring section as another DDoS detection tool for network infrastructure.