### PR TITLE
Add PING IP to DevNet tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [DNSlookup](https://dnslookup.pro/) - Easy DNS lookup Tools
 - [What is my isp](https://whois-myisp.com/) -  tool to find ISP name
 - [iptoolspro.com](https://iptoolspro.com) - Free browser-based network tools: IP lookup, DNS lookup, port checker, traceroute, MAC address lookup, VPN leak test, IP blacklist check, and more.
+- [PING IP](https://pingip.co/) - Browser-based IP lookup and risk-checking tool with WHOIS, ASN, ISP, IDC/home broadband detection, and WebRTC leak checks.
 
 ## DevNet Monitoring
 - [netdata](https://github.com/firehol/netdata) - Distributed real-time performance and health monitoring.
@@ -204,5 +205,4 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [Cisco Tools](https://www.cisco.com/c/en/us/support/web/tools-catalog.html) - List of Cisco tools maintained by Cisco.
 - [Juniper Day One Books](https://www.juniper.net/documentation/jnbooks/us/en/day-one-books) - Day One Books cover networking technologies using step-by-step instructions and practical examples written by working engineers
 - [Network Lab Pro Edition](https://chaithu-lets-code.github.io/SubnetPro) - Network reference and utilities
-
 


### PR DESCRIPTION
This adds PING IP to the DevNet Tools section.

PING IP is a browser-based IP lookup and risk-checking tool that includes WHOIS, ASN, ISP, IDC/home broadband detection, and WebRTC leak checks. It fits alongside the existing online IP, ISP, DNS, and network utility resources in this section.