### PR TITLE
Add MoonProxy to Network Connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [Prosimo](https://prosimo.io/) - Autonomous Multi-Cloud Network (commercial)
 - [Subtelforum Online Map](https://subtelforum.com/online-map/) - Submarine cables map
 - [Megaport](https://www.megaport.com/) - Network as a Service (NaaS) platform (commercial)
+- [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - Open-source cross-platform GUI desktop client for FRP (fast reverse proxy), enabling NAT traversal without touching the command line.
 
 # Network Operations
 ## Network Change Management


### PR DESCRIPTION
## What is MoonProxy?

[MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) is an open-source, cross-platform GUI desktop client for [FRP](https://github.com/fatedier/frp) (fast reverse proxy). It enables NAT traversal — exposing local services to the public internet — without touching the command line.

## Why add it?

- **Category fit:** NAT traversal / network connectivity tool — fills a gap in the Network Connectivity section, which currently has no consumer-facing GUI tool for reverse tunneling.
- **Open-source** (MIT license), actively maintained (latest release v1.2.0).
- **Cross-platform:** macOS (Apple Silicon + Intel) and Windows x64.
- **Built with Tauri v2 + Vue 3 + Rust** — modern, lightweight (~10 MB), no Electron bloat.
- **No Star threshold** — listed under MIT license, no entry barriers.

## Placement

Added to the **Network Connectivity** section, as MoonProxy directly addresses network connectivity by enabling users to reach local services from anywhere via FRP tunnels.

Thanks for maintaining this list! 🙏