### PR TITLE
Add Valla DNS to DevNet Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [DNSlookup](https://dnslookup.pro/) - Easy DNS lookup Tools
 - [What is my isp](https://whois-myisp.com/) -  tool to find ISP name
 - [iptoolspro.com](https://iptoolspro.com) - Free browser-based network tools: IP lookup, DNS lookup, port checker, traceroute, MAC address lookup, VPN leak test, IP blacklist check, and more.
+- [Valla DNS](https://valladns.com) - Free, no-signup browser-based DNS, WHOIS, propagation, SSL and email-health (SPF/DKIM/DMARC/MX) checker with a global propagation map.
 
 ## DevNet Monitoring
 - [netdata](https://github.com/firehol/netdata) - Distributed real-time performance and health monitoring.


### PR DESCRIPTION
Adds [Valla DNS](https://valladns.com) under **DevNet Tools**.

It is a free, no-signup browser-based network tool suite: DNS lookup, DNS propagation (global resolvers with a map), WHOIS, SSL/TLS, email health (SPF/DKIM/DMARC/MX), plus ping, traceroute, reverse DNS and IP info. It sits alongside existing hosted entries here such as NsLookup.io, DNSlookup and iptoolspro.com. Single entry, no signup or paywall.