### PR TITLE
Add Nutilz IP Lookup to DevNet Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [DNSlookup](https://dnslookup.pro/) - Easy DNS lookup Tools
 - [What is my isp](https://whois-myisp.com/) -  tool to find ISP name
 - [iptoolspro.com](https://iptoolspro.com) - Free browser-based network tools: IP lookup, DNS lookup, port checker, traceroute, MAC address lookup, VPN leak test, IP blacklist check, and more.
+- [Nutilz IP Lookup](https://nutilz.com/ip-lookup) - Free IP lookup tool showing geolocation (city, region, country), ISP/ASN, timezone with live local time, and a WebRTC leak check for your real public IP.
 
 ## DevNet Monitoring
 - [netdata](https://github.com/firehol/netdata) - Distributed real-time performance and health monitoring.


### PR DESCRIPTION
Adds a free, browser-based IP lookup tool (nutilz.com/ip-lookup) to the DevNet Tools section, alongside similar entries like iptoolspro.com. It shows IP geolocation (city/region/country), ISP/ASN, timezone with live local time, and includes a WebRTC leak check to reveal your real public IP behind a VPN/proxy. No signup required.