### PR TITLE
Add ACI MCP to AI for Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [Cisco LLM Security Leaderboard](https://leaderboard.aidefense.cisco.com/methodology) - Comprehensive model safety and security rankings, including single-turn score, multi-turn score, and detailed metrics.
 - [NetClaw](https://github.com/automateyournetwork/netclaw) - A CCIE-level AI network engineering coworker, built on OpenClaw
 - [DefenseClaw](https://github.com/cisco-ai-defense/defenseclaw) - DefenseClaw is the enterprise governance layer for OpenClaw
-- [ACI MCP](https://github.com/k3l0-dev/aci-mcp) - MCP server that lets an LLM query a Cisco ACI fabric by reading the APIC's own object model, so classes are discovered rather than hardcoded. Read-only, free for non-commercial use.
+- [niwashi-mcp](https://github.com/k3l0-dev/niwashi-mcp) - MCP server that lets an LLM query a Cisco ACI fabric by reading the APIC's own object model, so all 15,452 classes are discovered rather than hardcoded. Install with `uvx niwashi-mcp`. Read-only, free for non-commercial use.
 
 ## Network Monitoring
 - [rkik](https://github.com/aguacero7/rkik) - Light, easy-to-use monitoring tool for NTP servers

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [Cisco LLM Security Leaderboard](https://leaderboard.aidefense.cisco.com/methodology) - Comprehensive model safety and security rankings, including single-turn score, multi-turn score, and detailed metrics.
 - [NetClaw](https://github.com/automateyournetwork/netclaw) - A CCIE-level AI network engineering coworker, built on OpenClaw
 - [DefenseClaw](https://github.com/cisco-ai-defense/defenseclaw) - DefenseClaw is the enterprise governance layer for OpenClaw
+- [ACI MCP](https://github.com/k3l0-dev/aci-mcp) - MCP server that lets an LLM query a Cisco ACI fabric by reading the APIC's own object model, so classes are discovered rather than hardcoded. Read-only, free for non-commercial use.
 
 ## Network Monitoring
 - [rkik](https://github.com/aguacero7/rkik) - Light, easy-to-use monitoring tool for NTP servers


### PR DESCRIPTION
Adds [k3l0-dev/aci-mcp](https://github.com/k3l0-dev/aci-mcp) to **AI for Networking**.

It is an MCP server for Cisco ACI. Instead of wrapping a fixed list of APIC endpoints, it reads the fabric's own jsonmeta schemas: the agent searches for the class it needs, inspects that class's identifiers, containment and relations, and only then queries. That ordering matters on ACI specifically — the APIC answers an unknown class or a misspelled attribute with an empty result rather than an error, so an agent that guesses fails silently. Read-only, five tools, all 15,000+ classes reachable.

Format follows `contributing.md`: `[Name](link) - Description.`, added under the existing category, linked to the GitHub source.

One thing stated plainly rather than left to be found: the licence is PolyForm Noncommercial 1.0.0 — free for non-commercial use, commercial licence available. I have noted that in the entry. Happy to reword or withdraw if it does not fit the list.