### PR TITLE
Add Rockxy to DevNet Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
 - [DNSlookup](https://dnslookup.pro/) - Easy DNS lookup Tools
 - [What is my isp](https://whois-myisp.com/) -  tool to find ISP name
 - [iptoolspro.com](https://iptoolspro.com) - Free browser-based network tools: IP lookup, DNS lookup, port checker, traceroute, MAC address lookup, VPN leak test, IP blacklist check, and more.
+- [Rockxy](https://github.com/RockxyApp/Rockxy) - Native macOS HTTP debugging proxy for inspecting HTTPS, API, WebSocket, and GraphQL traffic.
 
 ## DevNet Monitoring
 - [netdata](https://github.com/firehol/netdata) - Distributed real-time performance and health monitoring.


### PR DESCRIPTION
Adds [Rockxy](https://github.com/RockxyApp/Rockxy) to the DevNet Tools section.

Rockxy is a native macOS HTTP debugging proxy for inspecting HTTPS, API, WebSocket, and GraphQL traffic. It fits this section as a developer-facing network troubleshooting tool with interception, inspection, and response-mocking capabilities.

- AGPL-3.0 licensed source
- Actively maintained
- Official GitHub source link
- Guideline-formatted one-line entry